### PR TITLE
Fix/z index on default modal container

### DIFF
--- a/src/DefaultModalContainer.js
+++ b/src/DefaultModalContainer.js
@@ -12,7 +12,8 @@ const overlayStyle = {
   width: '100%',
   padding: 0,
   margin: 0,
-  border: 0
+  border: 0,
+  zIndex: 2
 }
 
 const Overlay = ({ closeOnOverlayClick, closeModal }) => closeOnOverlayClick

--- a/src/__snapshots__/ModalProvider.test.js.snap
+++ b/src/__snapshots__/ModalProvider.test.js.snap
@@ -23,7 +23,7 @@ exports[`ModalProvider calling closeModal should render snapshots: before closeM
 </div>
 <div>
   <div style="align-items: flex-start; bottom: 0px; display: flex; justify-content: center; left: 0px; max-height: 100vh; max-width: 100vw; overflow: auto; position: fixed; right: 0px; top: 0px;">
-    <div style="background-color: rgba(0, 0, 0, 0.2); bottom: 0px; left: 0px; position: fixed; right: 0px; top: 0px; transform: translate3d(0px, -1px, 0px); width: 100%; padding: 0px; margin: 0px; border: 0px;">
+    <div style="background-color: rgba(0, 0, 0, 0.2); bottom: 0px; left: 0px; position: fixed; right: 0px; top: 0px; transform: translate3d(0px, -1px, 0px); width: 100%; padding: 0px; margin: 0px; border: 0px; z-index: 2;">
     </div>
     <div role="dialog"
          style="background-color: rgb(255, 255, 255); margin: 3rem auto; max-width: 100vw; padding: 1.5rem; transform: translate3d(0px, 1px, 0px); width: 80rem;"
@@ -42,7 +42,7 @@ exports[`ModalProvider calling openModal should render snapshots: after openModa
 </div>
 <div>
   <div style="align-items: flex-start; bottom: 0px; display: flex; justify-content: center; left: 0px; max-height: 100vh; max-width: 100vw; overflow: auto; position: fixed; right: 0px; top: 0px;">
-    <div style="background-color: rgba(0, 0, 0, 0.2); bottom: 0px; left: 0px; position: fixed; right: 0px; top: 0px; transform: translate3d(0px, -1px, 0px); width: 100%; padding: 0px; margin: 0px; border: 0px;">
+    <div style="background-color: rgba(0, 0, 0, 0.2); bottom: 0px; left: 0px; position: fixed; right: 0px; top: 0px; transform: translate3d(0px, -1px, 0px); width: 100%; padding: 0px; margin: 0px; border: 0px; z-index: 2;">
     </div>
     <div role="dialog"
          style="background-color: rgb(255, 255, 255); margin: 3rem auto; max-width: 100vw; padding: 1.5rem; transform: translate3d(0px, 1px, 0px); width: 80rem;"
@@ -77,7 +77,7 @@ exports[`ModalProvider passing closeOnOverlayClick=true should render snapshots:
 </div>
 <div>
   <div style="align-items: flex-start; bottom: 0px; display: flex; justify-content: center; left: 0px; max-height: 100vh; max-width: 100vw; overflow: auto; position: fixed; right: 0px; top: 0px;">
-    <button style="background-color: rgba(0, 0, 0, 0.2); bottom: 0px; left: 0px; position: fixed; right: 0px; top: 0px; transform: translate3d(0px, -1px, 0px); width: 100%; padding: 0px; margin: 0px; border: 0px;"
+    <button style="background-color: rgba(0, 0, 0, 0.2); bottom: 0px; left: 0px; position: fixed; right: 0px; top: 0px; transform: translate3d(0px, -1px, 0px); width: 100%; padding: 0px; margin: 0px; border: 0px; z-index: 2;"
             data-testid="overlay"
     >
     </button>
@@ -110,7 +110,7 @@ exports[`ModalProvider passing custom ContentWrapper should match snapshots: wit
 </div>
 <div>
   <div style="align-items: flex-start; bottom: 0px; display: flex; justify-content: center; left: 0px; max-height: 100vh; max-width: 100vw; overflow: auto; position: fixed; right: 0px; top: 0px;">
-    <div style="background-color: rgba(0, 0, 0, 0.2); bottom: 0px; left: 0px; position: fixed; right: 0px; top: 0px; transform: translate3d(0px, -1px, 0px); width: 100%; padding: 0px; margin: 0px; border: 0px;">
+    <div style="background-color: rgba(0, 0, 0, 0.2); bottom: 0px; left: 0px; position: fixed; right: 0px; top: 0px; transform: translate3d(0px, -1px, 0px); width: 100%; padding: 0px; margin: 0px; border: 0px; z-index: 2;">
     </div>
     <div role="dialog"
          style="background-color: rgb(255, 255, 255); margin: 3rem auto; max-width: 100vw; padding: 1.5rem; transform: translate3d(0px, 1px, 0px); width: 80rem;"
@@ -129,7 +129,7 @@ exports[`ModalProvider passing custom ModalComponent should match snapshot 1`] =
 </div>
 <div>
   <div style="align-items: flex-start; bottom: 0px; display: flex; justify-content: center; left: 0px; max-height: 100vh; max-width: 100vw; overflow: auto; position: fixed; right: 0px; top: 0px;">
-    <div style="background-color: rgba(0, 0, 0, 0.2); bottom: 0px; left: 0px; position: fixed; right: 0px; top: 0px; transform: translate3d(0px, -1px, 0px); width: 100%; padding: 0px; margin: 0px; border: 0px;">
+    <div style="background-color: rgba(0, 0, 0, 0.2); bottom: 0px; left: 0px; position: fixed; right: 0px; top: 0px; transform: translate3d(0px, -1px, 0px); width: 100%; padding: 0px; margin: 0px; border: 0px; z-index: 2;">
     </div>
     <div data-testid="modal-component">
       content
@@ -163,7 +163,7 @@ exports[`ModalProvider providing content should render snapshot 1`] = `
 </div>
 <div>
   <div style="align-items: flex-start; bottom: 0px; display: flex; justify-content: center; left: 0px; max-height: 100vh; max-width: 100vw; overflow: auto; position: fixed; right: 0px; top: 0px;">
-    <div style="background-color: rgba(0, 0, 0, 0.2); bottom: 0px; left: 0px; position: fixed; right: 0px; top: 0px; transform: translate3d(0px, -1px, 0px); width: 100%; padding: 0px; margin: 0px; border: 0px;">
+    <div style="background-color: rgba(0, 0, 0, 0.2); bottom: 0px; left: 0px; position: fixed; right: 0px; top: 0px; transform: translate3d(0px, -1px, 0px); width: 100%; padding: 0px; margin: 0px; border: 0px; z-index: 2;">
     </div>
     <div role="dialog"
          style="background-color: rgb(255, 255, 255); margin: 3rem auto; max-width: 100vw; padding: 1.5rem; transform: translate3d(0px, 1px, 0px); width: 80rem;"

--- a/src/__snapshots__/createModalProvider.test.js.snap
+++ b/src/__snapshots__/createModalProvider.test.js.snap
@@ -7,7 +7,7 @@ exports[`createModalProvider should be able to optionaly close the modal on over
 </div>
 <div>
   <div style="align-items: flex-start; bottom: 0px; display: flex; justify-content: center; left: 0px; max-height: 100vh; max-width: 100vw; overflow: auto; position: fixed; right: 0px; top: 0px;">
-    <button style="background-color: rgba(0, 0, 0, 0.2); bottom: 0px; left: 0px; position: fixed; right: 0px; top: 0px; transform: translate3d(0px, -1px, 0px); width: 100%; padding: 0px; margin: 0px; border: 0px;"
+    <button style="background-color: rgba(0, 0, 0, 0.2); bottom: 0px; left: 0px; position: fixed; right: 0px; top: 0px; transform: translate3d(0px, -1px, 0px); width: 100%; padding: 0px; margin: 0px; border: 0px; z-index: 2;"
             data-testid="overlay"
     >
     </button>
@@ -36,7 +36,7 @@ exports[`createModalProvider should pass custom props 1`] = `
 </div>
 <div>
   <div style="align-items: flex-start; bottom: 0px; display: flex; justify-content: center; left: 0px; max-height: 100vh; max-width: 100vw; overflow: auto; position: fixed; right: 0px; top: 0px;">
-    <div style="background-color: rgba(0, 0, 0, 0.2); bottom: 0px; left: 0px; position: fixed; right: 0px; top: 0px; transform: translate3d(0px, -1px, 0px); width: 100%; padding: 0px; margin: 0px; border: 0px;">
+    <div style="background-color: rgba(0, 0, 0, 0.2); bottom: 0px; left: 0px; position: fixed; right: 0px; top: 0px; transform: translate3d(0px, -1px, 0px); width: 100%; padding: 0px; margin: 0px; border: 0px; z-index: 2;">
     </div>
     <div role="dialog"
          style="background-color: rgb(255, 255, 255); margin: 3rem auto; max-width: 100vw; padding: 1.5rem; transform: translate3d(0px, 1px, 0px); width: 80rem;"


### PR DESCRIPTION
No IE/Edge é necessário fixar um z-index no overlay para que o modal fique na frente de elementos que têm position fixed/absolute, mesmo que esses elementos nao tenham z-index, o IE/Edge trata diferente. Setei z-index de 2, pois me parece válido que o container default coloque o modal a frente na maioria dos casos, e em casos especificos em que se precise de z-index maior, será necessário customizar o modalContainer.